### PR TITLE
Fixing Upgrade button not appearing for Parklife and Campus pedestria…

### DIFF
--- a/NaturalResourcesBrush/Detours/BeautificationPanelDetour.cs
+++ b/NaturalResourcesBrush/Detours/BeautificationPanelDetour.cs
@@ -45,7 +45,9 @@ namespace NaturalResourcesBrush.Detours
                 NetTool netTool = SetTool<NetTool>();
                 if (netTool != null)
                 {
-                    if (netInfo.GetClassLevel() == ItemClass.Level.Level3)
+                    if (netInfo.m_class?.name == "Pedestrian Way")
+                        this.ShowPathsOptionPanel();
+                    else if (netInfo.GetClassLevel() == ItemClass.Level.Level3)
                         this.ShowFloodwallsOptionPanel();
                     else if (netInfo.GetClassLevel() == ItemClass.Level.Level4)
                         this.ShowQuaysOptionPanel();


### PR DESCRIPTION
Currently the pedestrian ways added by the Parklife and Campus DLCs are seen as floodwalls, and therefore do not propose the upgrade button. I've just added a test to the selected item's classname which fixes this issue.