### PR TITLE
Fixed a bug assigning the correct option panel to Park Life pedestrian paths.

### DIFF
--- a/NaturalResourcesBrush/Detours/BeautificationPanelDetour.cs
+++ b/NaturalResourcesBrush/Detours/BeautificationPanelDetour.cs
@@ -45,7 +45,8 @@ namespace NaturalResourcesBrush.Detours
                 NetTool netTool = SetTool<NetTool>();
                 if (netTool != null)
                 {
-                    if (netInfo.GetClassLevel() == ItemClass.Level.Level3)
+                    // The pedestrian paths introduced by Park Life are class level 3
+                    if (netInfo.GetClassLevel() == ItemClass.Level.Level3 && !netInfo.m_hasPedestrianLanes)
                         this.ShowFloodwallsOptionPanel();
                     else if (netInfo.GetClassLevel() == ItemClass.Level.Level4)
                         this.ShowQuaysOptionPanel();


### PR DESCRIPTION
The pedestrian paths added with Park Life use class level 3 and so were being incorrectly identified as flood walls during option panel selection. A condition was added to option panel selection allowing networks with pedestrian lanes to fall through to the default path option panel.